### PR TITLE
fix: Terraformプロバイダーのバージョンを固定

### DIFF
--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -2,12 +2,12 @@ terraform {
   required_version = ">= 1.9.5"
   required_providers {
     azurerm = {
-      version = "~>4.0"
+      version = "4.18.0"
       source  = "hashicorp/azurerm"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.6"
+      version = "3.6.3"
     }
   }
 }


### PR DESCRIPTION
## 概要
Terraformプロバイダーのバージョンを固定し、インフラの安定性とビルドの再現性を向上させました。

## 変更箇所
- `azurerm`プロバイダーのバージョンを`~>4.0`から`4.18.0`に固定
- `random`プロバイダーのバージョンを`~> 3.6`から`3.6.3`に固定

## プロバイダーバージョン変更の詳細

### 変更前後の比較

```diff
terraform {
  required_version = ">= 1.9.5"
  required_providers {
    azurerm = {
-      version = "~>4.0"
+      version = "4.18.0"
      source  = "hashicorp/azurerm"
    }
    random = {
      source  = "hashicorp/random"
-      version = "~> 3.6"
+      version = "3.6.3"
    }
  }
}
```

## 備考
- プロバイダーのバージョン固定により、予期しない動作変更を防ぎ、インフラの安定性を向上
- 今後プロバイダーをアップデートする際は、計画的に実施し、十分なテストを行うことを推奨